### PR TITLE
autoscan: Add missing inotify rewrite to template

### DIFF
--- a/roles/autoscan/templates/config.yml.j2
+++ b/roles/autoscan/templates/config.yml.j2
@@ -50,8 +50,8 @@ triggers:
 
       # rewrite inotify path to unified filesystem
       rewrite:
-            - from: ^/mnt/local/Media/
-              to: /mnt/unionfs/Media/
+        - from: ^/mnt/local/Media/
+          to: /mnt/unionfs/Media/
 
       # Local filesystem paths to monitor
       paths:

--- a/roles/autoscan/templates/config.yml.j2
+++ b/roles/autoscan/templates/config.yml.j2
@@ -48,6 +48,11 @@ triggers:
       exclude:
         - '\.(srt|pdf)$'
 
+      # rewrite inotify path to unified filesystem
+      rewrite:
+            - from: ^/mnt/local/Media/
+              to: /mnt/unionfs/Media/
+
       # Local filesystem paths to monitor
       paths:
         - path: /mnt/local/Media


### PR DESCRIPTION
Apparently this rewrite has been missing for the inotify trigger the whole time, might have been too aggressive removing rewrites from the stock autoscan config at the time. Oops.