### PR TITLE
Cloudplow role error

### DIFF
--- a/roles/cloudplow/tasks/subtasks/settings.yml
+++ b/roles/cloudplow/tasks/subtasks/settings.yml
@@ -60,12 +60,15 @@
         jq '.plex.url = "{{ plex_web_url }}"' {{ cloudplow_config_path }} | sponge {{ cloudplow_config_path }}
       become: true
       become_user: "{{ user.name }}"
+      vars:
+        plex_name: "{{ plex_instances[0] }}"
 
     - name: Settings | Update Plex Token in 'config.json'
       ansible.builtin.shell: |
         jq '.plex.token = "{{ plex_auth_token | default('') }}"' {{ cloudplow_config_path }} | sponge {{ cloudplow_config_path }}
       become: true
       become_user: "{{ user.name }}"
+
 
   when: cloudplow_config.stat.exists
 


### PR DESCRIPTION
When re running the cloudplow role, I would get this error message:
```
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ 'https://' +
lookup('vars', plex_name + '_web_subdomain', default=plex_web_subdomain) + '.' + lookup('vars', plex_name +
'_web_domain', default=plex_web_domain) if (reverse_proxy_is_enabled) else 'http://localhost:' + lookup('vars', plex_name +
'_web_port', default=plex_web_port) }}: {{ plex_name }}: 'plex_name' is undefined\n\nThe error appears to be in
'/srv/git/saltbox/roles/cloudplow/tasks/subtasks/settings.yml': line 58, column 7, but may\nbe elsewhere in the file depending on
the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Settings | Update Plex URL in 'config.json'\n     
^ here\n"}
```

Adding the var to the plex url task appears to fix.
