### PR TITLE
Allow iframe access for subdomains in organizr

### DIFF
--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -17,6 +17,9 @@ server:
   enable_pprof: false
   enable_expvars: false
   disable_healthcheck: false
+  headers:
+    ## The CSP Template. Read the docs.
+    csp_template: "frame-ancestors 'self' {{ user.domain }} {{ '*.' + user.domain }}"
 
 log:
   level: info


### PR DESCRIPTION
This fixes the problem where adding tabs protected by authelia to organizr will get a "refused connection" because authelia blocks all iframe embeds. This will allow iframes from all subdomains