### PR TITLE
Docker: Add docker-compose tag

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -104,6 +104,7 @@
 
 - name: "Import Compose tasks"
   ansible.builtin.import_tasks: "subtasks/compose.yml"
+  tags: docker-compose
 
 - name: "Install ctop"
   ansible.builtin.import_role:


### PR DESCRIPTION
Add `docker-compose` tag for running Compose tasks only (i.e. updating `docker compose`)