### PR TITLE
Set balance and scrub mountpoints to 'auto'

### DIFF
--- a/roles/btrfsmaintenance/tasks/main.yml
+++ b/roles/btrfsmaintenance/tasks/main.yml
@@ -46,9 +46,13 @@
     - name: "Change mountpoints to 'auto'"
       ansible.builtin.lineinfile:
         path: "/opt/btrfsmaintenance/sysconfig.btrfsmaintenance"
-        regexp: '^BTRFS_TRIM_MOUNTPOINTS\s?='
-        line: 'BTRFS_TRIM_MOUNTPOINTS="auto"'
+        regexp: '^{{ item }}\s?='
+        line: '{{ item }}="auto"'
         state: present
+      loop:
+        - BTRFS_TRIM_MOUNTPOINTS
+        - BTRFS_BALANCE_MOUNTPOINTS
+        - BTRFS_SCRUB_MOUNTPOINTS
 
     - name: "Execute dist-install.sh"
       become: true


### PR DESCRIPTION
Set `BTRFS_BALANCE_MOUNTPOINTS` and `BTRFS_SCRUB_MOUNTPOINTS` to 'auto' so the role will work with btrfs partitions other than `/`.