### PR TITLE
Update diun.yml (Diun role)

### DIFF
--- a/roles/diun/files/diun.yml
+++ b/roles/diun/files/diun.yml
@@ -24,16 +24,16 @@ providers:
 #     username: foo
 #     password: bar
 
-# notif:
-#   discord:
-#     webhookURL: https://discordapp.com/api/webhooks/1234567890/Abcd-eFgh-iJklmNo_pqr
-#     mentions:
-#       - "@here"
-#       - "@everyone"
-#       - "<@124>"
-#       - "<@125>"
-#       - "<@&200>"
-#     renderFields: true
-#     timeout: 10s
-#     templateBody: |
-#       Docker tag {{ .Entry.Image }} which you subscribed to through {{ .Entry.Provider }} provider has been released.
+#notif:
+#  discord:
+#    webhookURL: https://discordapp.com/api/webhooks/1234567890/Abcd-eFgh-iJklmNo_pqr
+#    mentions:
+#      - "@here"
+#      - "@everyone"
+#      - "<@124>"
+#      - "<@125>"
+#      - "<@&200>"
+#    renderFields: true
+#    timeout: 10s
+#    templateBody: |
+#      Docker tag {{ .Entry.Image }} which you subscribed to through {{ .Entry.Provider }} provider has been released.


### PR DESCRIPTION
removed added space from after #s in the diun.yml file under "files" so when you remove comments, the role will not fail. format should be 
```yaml
notif:
  discord:
    webhookURL: https://discord.com/api/webhooks/yes/no
    ...
```
not 
```yaml
 notif
   discord:
     webhookURL:
     ...
```
this could be intentional, so please forgive if this is redundant. Just made starting the role take a while, I had to mess with it more than I'd have needed to otherwise. : )