### PR TITLE
Theme-Park: Add Support for Traefik Plugin

### DIFF
--- a/inventories/group_vars/all.yml
+++ b/inventories/group_vars/all.yml
@@ -175,6 +175,7 @@ reverse_proxy_is_enabled: "{{ (user is defined) and
 # Options can be found at https://github.com/gilbN/theme.park
 global_themepark_theme: organizr
 global_themepark_domain: theme-park.dev
+global_themepark_plugin_enabled: false
 
 ################################
 # Authelia

--- a/roles/emby/defaults/main.yml
+++ b/roles/emby/defaults/main.yml
@@ -65,7 +65,7 @@ emby_traefik_middleware: "{{ emby_traefik_middleware_default + ','
                              + emby_traefik_themepark_middleware
                           if (not emby_traefik_middleware_custom.startswith(',') and emby_traefik_middleware_custom | length > 0)
                           else emby_traefik_middleware_default
-                             + emby_traefik_middleware_custom 
+                             + emby_traefik_middleware_custom
                              + emby_traefik_themepark_middleware }}"
 
 emby_traefik_certresolver: "{{ traefik_default_certresolver }}"

--- a/roles/emby/defaults/main.yml
+++ b/roles/emby/defaults/main.yml
@@ -61,11 +61,11 @@ emby_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                   else traefik_default_middleware }}"
 emby_traefik_middleware_custom: ""
 emby_traefik_middleware: "{{ emby_traefik_middleware_default + ','
-                             + emby_traefik_middleware_custom
+                             + emby_traefik_middleware_custom + ','
                              + emby_traefik_themepark_middleware
                           if (not emby_traefik_middleware_custom.startswith(',') and emby_traefik_middleware_custom | length > 0)
                           else emby_traefik_middleware_default
-                             + emby_traefik_middleware_custom
+                             + emby_traefik_middleware_custom + ','
                              + emby_traefik_themepark_middleware }}"
 
 emby_traefik_certresolver: "{{ traefik_default_certresolver }}"

--- a/roles/emby/defaults/main.yml
+++ b/roles/emby/defaults/main.yml
@@ -53,6 +53,7 @@ emby_dns_proxy: "{{ dns.proxied }}"
 ################################
 
 emby_traefik_sso_middleware: ""
+emby_traefik_themepark_middleware: "{{ 'themepark-emby@file' if (emby_themepark_enabled) (global_themepark_plugin_enabled)| '' }}"
 
 emby_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                      + lookup('vars', emby_name + '_traefik_sso_middleware', default=emby_traefik_sso_middleware)
@@ -61,13 +62,23 @@ emby_traefik_middleware_default: "{{ traefik_default_middleware + ','
 emby_traefik_middleware_custom: ""
 emby_traefik_middleware: "{{ emby_traefik_middleware_default + ','
                              + emby_traefik_middleware_custom
+                             + emby_traefik_themepark_middleware
                           if (not emby_traefik_middleware_custom.startswith(',') and emby_traefik_middleware_custom | length > 0)
                           else emby_traefik_middleware_default
-                             + emby_traefik_middleware_custom }}"
+                             + emby_traefik_middleware_custom 
+                             + emby_traefik_themepark_middleware }}"
 
 emby_traefik_certresolver: "{{ traefik_default_certresolver }}"
 emby_traefik_enabled: true
 emby_traefik_gzip_enabled: false
+
+################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+emby_themepark_enabled: false
+emby_themepark_theme: "{{ global_themepark_theme }}"
 
 ################################
 # Settings

--- a/roles/emby/defaults/main.yml
+++ b/roles/emby/defaults/main.yml
@@ -53,7 +53,7 @@ emby_dns_proxy: "{{ dns.proxied }}"
 ################################
 
 emby_traefik_sso_middleware: ""
-emby_traefik_themepark_middleware: "{{ 'themepark-emby@file' if (emby_themepark_enabled) (global_themepark_plugin_enabled)| '' }}"
+emby_traefik_themepark_middleware: "{{ 'themepark-emby@file' if (emby_themepark_enabled and global_themepark_plugin_enabled) else '' }}"
 
 emby_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                      + lookup('vars', emby_name + '_traefik_sso_middleware', default=emby_traefik_sso_middleware)

--- a/roles/nzbhydra2/defaults/main.yml
+++ b/roles/nzbhydra2/defaults/main.yml
@@ -48,6 +48,7 @@ nzbhydra2_dns_proxy: "{{ dns.proxied }}"
 ################################
 
 nzbhydra2_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+nzbhydra2_traefik_themepark_middleware: "{{ 'themepark-nzbhydra2@file' if (nzbhydra2_themepark_enabled and global_themepark_plugin_enabled) else '' }}"
 
 nzbhydra2_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                           + lookup('vars', nzbhydra2_name + '_traefik_sso_middleware', default=nzbhydra2_traefik_sso_middleware)
@@ -56,13 +57,23 @@ nzbhydra2_traefik_middleware_default: "{{ traefik_default_middleware + ','
 nzbhydra2_traefik_middleware_custom: ""
 nzbhydra2_traefik_middleware: "{{ nzbhydra2_traefik_middleware_default + ','
                                   + nzbhydra2_traefik_middleware_custom
+                                  + nzbhydra2_traefik_themepark_middleware
                                if (not nzbhydra2_traefik_middleware_custom.startswith(',') and nzbhydra2_traefik_middleware_custom | length > 0)
                                else nzbhydra2_traefik_middleware_default
-                                  + nzbhydra2_traefik_middleware_custom }}"
+                                  + nzbhydra2_traefik_middleware_custom
+                                  + nzbhydra2_traefik_themepark_middleware }}"
 nzbhydra2_traefik_certresolver: "{{ traefik_default_certresolver }}"
 nzbhydra2_traefik_enabled: true
 nzbhydra2_traefik_api_enabled: true
 nzbhydra2_traefik_api_endpoint: "`/api`,`/getnzb`,`/gettorrent`,`/rss`,`/torznab/api`"
+
+################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+nzbhydra2_themepark_enabled: false
+nzbhydra2_themepark_theme: "{{ global_themepark_theme }}"
 
 ################################
 # Config

--- a/roles/nzbhydra2/defaults/main.yml
+++ b/roles/nzbhydra2/defaults/main.yml
@@ -56,11 +56,11 @@ nzbhydra2_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                        else traefik_default_middleware }}"
 nzbhydra2_traefik_middleware_custom: ""
 nzbhydra2_traefik_middleware: "{{ nzbhydra2_traefik_middleware_default + ','
-                                  + nzbhydra2_traefik_middleware_custom
+                                  + nzbhydra2_traefik_middleware_custom + ','
                                   + nzbhydra2_traefik_themepark_middleware
                                if (not nzbhydra2_traefik_middleware_custom.startswith(',') and nzbhydra2_traefik_middleware_custom | length > 0)
                                else nzbhydra2_traefik_middleware_default
-                                  + nzbhydra2_traefik_middleware_custom
+                                  + nzbhydra2_traefik_middleware_custom + ','
                                   + nzbhydra2_traefik_themepark_middleware }}"
 nzbhydra2_traefik_certresolver: "{{ traefik_default_certresolver }}"
 nzbhydra2_traefik_enabled: true

--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -54,7 +54,7 @@ overseerr_log_level: "info"
 # Traefik
 ################################
 
-overseerr_traefik_themepark_middleware: "{{ 'themepark-overseerr@file' if (overseerr_themepark_enabled) (global_themepark_plugin_enabled)| '' }}"
+overseerr_traefik_themepark_middleware: "{{ 'themepark-overseerr@file' if (overseerr_themepark_enabled and global_themepark_plugin_enabled) else '' }}"
 
 overseerr_traefik_middleware_default: "{{ traefik_default_middleware }}"
 overseerr_traefik_middleware_custom: ""

--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -63,7 +63,7 @@ overseerr_traefik_middleware: "{{ overseerr_traefik_middleware_default + ','
                                   + overseerr_themepark_middleware
                                if (not overseerr_traefik_middleware_custom.startswith(',') and overseerr_traefik_middleware_custom | length > 0)
                                else overseerr_traefik_middleware_default
-                                  + overseerr_traefik_middleware_custom 
+                                  + overseerr_traefik_middleware_custom
                                   + overseerr_themepark_middleware }}"
 
 overseerr_traefik_certresolver: "{{ traefik_default_certresolver }}"

--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -54,16 +54,28 @@ overseerr_log_level: "info"
 # Traefik
 ################################
 
+overseerr_traefik_themepark_middleware: "{{ 'themepark-overseerr@file' if (overseerr_themepark_enabled) (global_themepark_plugin_enabled)| '' }}"
+
 overseerr_traefik_middleware_default: "{{ traefik_default_middleware }}"
 overseerr_traefik_middleware_custom: ""
 overseerr_traefik_middleware: "{{ overseerr_traefik_middleware_default + ','
                                   + overseerr_traefik_middleware_custom
+                                  + overseerr_themepark_middleware
                                if (not overseerr_traefik_middleware_custom.startswith(',') and overseerr_traefik_middleware_custom | length > 0)
                                else overseerr_traefik_middleware_default
-                                  + overseerr_traefik_middleware_custom }}"
+                                  + overseerr_traefik_middleware_custom 
+                                  + overseerr_themepark_middleware }}"
 
 overseerr_traefik_certresolver: "{{ traefik_default_certresolver }}"
 overseerr_traefik_enabled: true
+
+################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+overseerr_themepark_enabled: false
+overseerr_themepark_theme: "{{ global_themepark_theme }}"
 
 ################################
 # Docker

--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -59,12 +59,12 @@ overseerr_traefik_themepark_middleware: "{{ 'themepark-overseerr@file' if (overs
 overseerr_traefik_middleware_default: "{{ traefik_default_middleware }}"
 overseerr_traefik_middleware_custom: ""
 overseerr_traefik_middleware: "{{ overseerr_traefik_middleware_default + ','
-                                  + overseerr_traefik_middleware_custom
-                                  + overseerr_themepark_middleware
+                                  + overseerr_traefik_middleware_custom + ','
+                                  + overseerr_traefik_themepark_middleware
                                if (not overseerr_traefik_middleware_custom.startswith(',') and overseerr_traefik_middleware_custom | length > 0)
                                else overseerr_traefik_middleware_default
-                                  + overseerr_traefik_middleware_custom
-                                  + overseerr_themepark_middleware }}"
+                                  + overseerr_traefik_middleware_custom + ','
+                                  + overseerr_traefik_themepark_middleware }}"
 
 overseerr_traefik_certresolver: "{{ traefik_default_certresolver }}"
 overseerr_traefik_enabled: true

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -101,7 +101,7 @@ plex_traefik_middleware: "{{ plex_traefik_middleware_default
                              + (','
                                if (not plex_traefik_middleware_custom.startswith(',') and plex_traefik_middleware_custom | length > 0)
                                else '')
-                             + plex_traefik_middleware_custom
+                             + plex_traefik_middleware_custom + ','
                              + plex_traefik_themepark_middleware }}"
 
 plex_traefik_certresolver: "{{ traefik_default_certresolver }}"

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -90,6 +90,7 @@ plex_traefik_middleware_http: "{{ 'globalHeaders@file'
                                else traefik_default_middleware_default_http }}"
 
 plex_traefik_sso_middleware: ""
+plex_traefik_themepark_middleware: "{{ 'themepark-plex@file' if (plex_themepark_enabled and global_themepark_plugin_enabled) else '' }}"
 
 plex_traefik_middleware_default: "{{ traefik_default_middleware
                                      + (',' + lookup('vars', plex_name + '_traefik_sso_middleware', default=plex_traefik_sso_middleware)
@@ -100,7 +101,8 @@ plex_traefik_middleware: "{{ plex_traefik_middleware_default
                              + (','
                                if (not plex_traefik_middleware_custom.startswith(',') and plex_traefik_middleware_custom | length > 0)
                                else '')
-                             + plex_traefik_middleware_custom }}"
+                             + plex_traefik_middleware_custom
+                             + plex_traefik_themepark_middleware }}"
 
 plex_traefik_certresolver: "{{ traefik_default_certresolver }}"
 plex_traefik_enabled: true
@@ -186,8 +188,6 @@ plex_docker_envs_default:
   NVIDIA_VISIBLE_DEVICES: "{{ 'all' if (gpu.nvidia) | default(false) else omit }}"
   TZ: "{{ tz }}"
   ADVERTISE_IP: "{{ plex_docker_envs_advertise_ip }}"
-  TP_DOMAIN: "{{ plex_themepark_domain }}"
-  TP_THEME: "{{ plex_themepark_theme }}"
 plex_docker_envs_custom: {}
 plex_docker_envs: "{{ lookup('vars', plex_name + '_docker_envs_default', default=plex_docker_envs_default)
                       | combine(lookup('vars', plex_name + '_docker_envs_custom', default=plex_docker_envs_custom)) }}"
@@ -208,13 +208,8 @@ plex_docker_volumes_default:
 plex_docker_volumes_custom: []
 plex_docker_volumes_modify:
   - "{{ plex_paths_location }}/99-modify-binary:/etc/cont-init.d/99-modify-binary"
-plex_docker_volumes_theme:
-  - "{{ plex_paths_location }}/98-themepark:/etc/cont-init.d/98-themepark"
 plex_docker_volumes: "{{ lookup('vars', plex_name + '_docker_volumes_default', default=plex_docker_volumes_default)
                          + lookup('vars', plex_name + '_docker_volumes_custom', default=plex_docker_volumes_custom)
-                         + (lookup('vars', plex_name + '_docker_volumes_theme', default=plex_docker_volumes_theme)
-                           if lookup('vars', plex_name + '_themepark_enabled', default=plex_themepark_enabled)
-                           else [])
                          + (lookup('vars', plex_name + '_docker_volumes_modify', default=plex_docker_volumes_modify)
                            if lookup('vars', plex_name + '_modify_binary', default=plex_modify_binary)
                            else []) }}"

--- a/roles/plex/tasks/main2.yml
+++ b/roles/plex/tasks/main2.yml
@@ -34,19 +34,6 @@
     mode: "0775"
   with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
 
-- name: Download 98-themepark
-  ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/GilbN/theme.park/master/docker-mods/plex/root/etc/cont-init.d/98-themepark"
-    dest: "{{ plex_paths_location }}"
-    owner: "{{ user.name }}"
-    group: "{{ user.name }}"
-    mode: "0770"
-    force: true
-  register: x
-  until: "x is not failed"
-  retries: 5
-  delay: 10
-
 - name: Pre-Install Tasks
   ansible.builtin.import_tasks: "subtasks/pre-install/main.yml"
   when: not continuous_integration

--- a/roles/portainer/defaults/main.yml
+++ b/roles/portainer/defaults/main.yml
@@ -46,6 +46,7 @@ portainer_dns_proxy: "{{ dns.proxied }}"
 ################################
 
 portainer_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+portainer_traefik_themepark_middleware: "{{ 'themepark-portainer@file' if (portainer_themepark_enabled and global_themepark_plugin_enabled) else '' }}"
 
 portainer_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                           + lookup('vars', portainer_name + '_traefik_sso_middleware', default=portainer_traefik_sso_middleware)
@@ -54,14 +55,24 @@ portainer_traefik_middleware_default: "{{ traefik_default_middleware + ','
 portainer_traefik_middleware_custom: ""
 portainer_traefik_middleware: "{{ portainer_traefik_middleware_default + ','
                                   + portainer_traefik_middleware_custom
+                                  + nzbhydra2_traefik_themepark_middleware
                                if (not portainer_traefik_middleware_custom.startswith(',') and portainer_traefik_middleware_custom | length > 0)
                                else portainer_traefik_middleware_default
-                                  + portainer_traefik_middleware_custom }}"
+                                  + portainer_traefik_middleware_custom
+                                  + nzbhydra2_traefik_themepark_middleware }}"
 portainer_traefik_middleware_api: "{{ traefik_global_middleware }}"
 portainer_traefik_certresolver: "{{ traefik_default_certresolver }}"
 portainer_traefik_enabled: true
 portainer_traefik_api_enabled: true
 portainer_traefik_api_endpoint: "`/api/websocket/`"
+
+################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+portainer_themepark_enabled: false
+portainer_themepark_theme: "{{ global_themepark_theme }}"
 
 ################################
 # Docker

--- a/roles/portainer/defaults/main.yml
+++ b/roles/portainer/defaults/main.yml
@@ -54,12 +54,12 @@ portainer_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                        else traefik_default_middleware }}"
 portainer_traefik_middleware_custom: ""
 portainer_traefik_middleware: "{{ portainer_traefik_middleware_default + ','
-                                  + portainer_traefik_middleware_custom
-                                  + nzbhydra2_traefik_themepark_middleware
+                                  + portainer_traefik_middleware_custom + ','
+                                  + portainer_traefik_themepark_middleware
                                if (not portainer_traefik_middleware_custom.startswith(',') and portainer_traefik_middleware_custom | length > 0)
                                else portainer_traefik_middleware_default
-                                  + portainer_traefik_middleware_custom
-                                  + nzbhydra2_traefik_themepark_middleware }}"
+                                  + portainer_traefik_middleware_custom + ','
+                                  + portainer_traefik_themepark_middleware }}"
 portainer_traefik_middleware_api: "{{ traefik_global_middleware }}"
 portainer_traefik_certresolver: "{{ traefik_default_certresolver }}"
 portainer_traefik_enabled: true

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -221,7 +221,7 @@ traefik_docker_commands_metrics: "{{ traefik_docker_commands_metrics_tmp
                                   else [] }}"
 traefik_docker_commands_themepark_plugin_tmp:
   - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
-  - "--experimental.plugins.traefik-themepark.version=v1.2.0"
+  - "--experimental.plugins.traefik-themepark.version=v1.2.2"
 traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
                                            if (global_themepark_plugin_enabled
                                            else [] }}"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -221,7 +221,7 @@ traefik_docker_commands_metrics: "{{ traefik_docker_commands_metrics_tmp
                                   else [] }}"
 traefik_docker_commands_themepark_plugin_tmp:
   - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
-  - "--experimental.plugins.traefik-themepark.version=v1.1.0"
+  - "--experimental.plugins.traefik-themepark.version=v1.2.0"
 traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
                                            if (global_themepark_plugin_enabled
                                            else [] }}"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -220,8 +220,8 @@ traefik_docker_commands_metrics: "{{ traefik_docker_commands_metrics_tmp
                                   if traefik.metrics
                                   else [] }}"
 traefik_docker_commands_themepark_plugin_tmp:
-  - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
-  - "--experimental.plugins.traefik-themepark.version=v1.2.2"
+  - "--experimental.plugins.themepark.modulename=github.com/packruler/traefik-themepark"
+  - "--experimental.plugins.themepark.version=v1.2.2"
 traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
                                            if global_themepark_plugin_enabled
                                            else [] }}"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -219,6 +219,12 @@ traefik_docker_commands_metrics_tmp:
 traefik_docker_commands_metrics: "{{ traefik_docker_commands_metrics_tmp
                                   if traefik.metrics
                                   else [] }}"
+traefik_docker_commands_themepark_plugin_tmp:
+  - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
+  - "--experimental.plugins.traefik-themepark.version=v1.1.0"
+traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
+                                          if (global_themepark_plugin_enabled
+                                          else [] }}"
 traefik_docker_commands_tracing_tmp:
   - "--tracing.serviceName=traefik"
   - "--tracing.spanNameLimit=250"
@@ -238,6 +244,7 @@ traefik_docker_commands_custom: []
 traefik_docker_commands: "{{ traefik_docker_commands_default
                              + traefik_docker_commands_custom
                              + traefik_docker_commands_metrics
+                             + traefik_docker_commands_theme
                              + traefik_docker_commands_tracing
                              + traefik_docker_commands_google_acme }}"
 

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -244,7 +244,7 @@ traefik_docker_commands_custom: []
 traefik_docker_commands: "{{ traefik_docker_commands_default
                              + traefik_docker_commands_custom
                              + traefik_docker_commands_metrics
-                             + traefik_docker_commands_theme
+                             + traefik_docker_commands_themepark_plugin
                              + traefik_docker_commands_tracing
                              + traefik_docker_commands_google_acme }}"
 

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -223,8 +223,8 @@ traefik_docker_commands_themepark_plugin_tmp:
   - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
   - "--experimental.plugins.traefik-themepark.version=v1.1.0"
 traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
-                                          if (global_themepark_plugin_enabled
-                                          else [] }}"
+                                           if (global_themepark_plugin_enabled
+                                           else [] }}"
 traefik_docker_commands_tracing_tmp:
   - "--tracing.serviceName=traefik"
   - "--tracing.spanNameLimit=250"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -223,7 +223,7 @@ traefik_docker_commands_themepark_plugin_tmp:
   - "--experimental.plugins.traefik-themepark.modulename=github.com/packruler/traefik-themepark"
   - "--experimental.plugins.traefik-themepark.version=v1.2.2"
 traefik_docker_commands_themepark_plugin: "{{ traefik_docker_commands_themepark_plugin_tmp
-                                           if (global_themepark_plugin_enabled
+                                           if global_themepark_plugin_enabled
                                            else [] }}"
 traefik_docker_commands_tracing_tmp:
   - "--tracing.serviceName=traefik"

--- a/roles/traefik/tasks/subtasks/config.yml
+++ b/roles/traefik/tasks/subtasks/config.yml
@@ -16,6 +16,16 @@
     group: "{{ user.name }}"
     mode: "0775"
 
+- name: "Import 'themepark.yml'"
+  ansible.builtin.template:
+    src: themepark.yml.j2
+    dest: "{{ traefik_paths_location }}/themepark.yml"
+    force: true
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+    when: global_themepark_plugin_enabled
+
 - name: Create auth file
   community.general.htpasswd:
     path: /opt/traefik/auth

--- a/roles/traefik/tasks/subtasks/config.yml
+++ b/roles/traefik/tasks/subtasks/config.yml
@@ -24,7 +24,7 @@
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: "0775"
-    when: global_themepark_plugin_enabled
+  when: global_themepark_plugin_enabled
 
 - name: Create auth file
   community.general.htpasswd:

--- a/roles/traefik/tasks/subtasks/config.yml
+++ b/roles/traefik/tasks/subtasks/config.yml
@@ -26,6 +26,12 @@
     mode: "0775"
   when: global_themepark_plugin_enabled
 
+- name: Remove 'themepark.yml'
+  ansible.builtin.file:
+    path: "{{ traefik_paths_location }}/themepark.yml"
+    state: absent
+  when: not global_themepark_plugin_enabled
+
 - name: Create auth file
   community.general.htpasswd:
     path: /opt/traefik/auth

--- a/roles/traefik/templates/themepark.yml.j2
+++ b/roles/traefik/templates/themepark.yml.j2
@@ -1,0 +1,72 @@
+http:
+  middlewares:
+    themepark-emby:
+      plugin:
+        themepark:
+          app: emby
+          theme: {{ emby_themepark_theme }}
+    themepark-overseerr:
+      plugin:
+        themepark:
+          app: overseerr
+          theme: {{ overseerr_themepark_theme }}
+    themepark-nzbhydra2:
+      plugin:
+        themepark:
+          app: nzbhydra2
+          theme: {{ nzbhydra2_themepark_theme }}
+    themepark-portainer:
+      plugin:
+        themepark:
+          app: portainer
+          theme: {{ portainer_themepark_theme }}
+    themepark-netdata:
+      plugin:
+        themepark:
+          app: netdata
+          theme: {{ netdata_themepark_theme }}
+    themepark-guacamole:
+      plugin:
+        themepark:
+          app: guacamole
+          theme: {{ guacamole_themepark_theme }}
+    themepark-requestrr:
+      plugin:
+        themepark:
+          app: requestrr
+          theme: {{ requestrr_themepark_theme }}
+    themepark-adguard:
+      plugin:
+        themepark:
+          app: adguard
+          theme: {{ adguard_themepark_theme }}
+    themepark-gaps:
+      plugin:
+        themepark:
+          app: gaps
+          theme: {{ gaps_themepark_theme }}
+    themepark-vailtwarden:
+      plugin:
+        themepark:
+          app: vaultwarden
+          theme: {{ vaultwarden_themepark_theme }}
+    themepark-kitana:
+      plugin:
+        themepark:
+          app: kitana
+          theme: {{ kitana_themepark_theme }}
+    themepark-resilio-sync:
+      plugin:
+        themepark:
+          app: resilio-sync
+          theme: {{ resilio_sync_themepark_theme }}
+    themepark-moviematch:
+      plugin:
+        themepark:
+          app: moviematch
+          theme: {{ moviematch_themepark_theme }}
+    themepark-petio:
+      plugin:
+        themepark:
+          app: petio
+          theme: {{ petio_themepark_theme }}

--- a/roles/traefik/templates/themepark.yml.j2
+++ b/roles/traefik/templates/themepark.yml.j2
@@ -4,74 +4,74 @@ http:
       plugin:
         themepark:
           app: emby
-          theme: {{ emby_themepark_theme }}
+          theme: {{ emby_themepark_theme | default (global_themepark_theme) }}
     themepark-overseerr:
       plugin:
         themepark:
           app: overseerr
-          theme: {{ overseerr_themepark_theme }}
+          theme: {{ overseerr_themepark_theme | default (global_themepark_theme) }}
     themepark-nzbhydra2:
       plugin:
         themepark:
           app: nzbhydra2
-          theme: {{ nzbhydra2_themepark_theme }}
+          theme: {{ nzbhydra2_themepark_theme | default (global_themepark_theme) }}
     themepark-plex:
       plugin:
         themepark:
           app: plex
-          theme: {{ plex_themepark_theme }}
+          theme: {{ plex_themepark_theme | default (global_themepark_theme) }}
     themepark-portainer:
       plugin:
         themepark:
           app: portainer
-          theme: {{ portainer_themepark_theme }}
+          theme: {{ portainer_themepark_theme | default (global_themepark_theme) }}
     themepark-netdata:
       plugin:
         themepark:
           app: netdata
-          theme: {{ netdata_themepark_theme }}
+          theme: {{ netdata_themepark_theme | default (global_themepark_theme) }}
     themepark-guacamole:
       plugin:
         themepark:
           app: guacamole
-          theme: {{ guacamole_themepark_theme }}
+          theme: {{ guacamole_themepark_theme | default (global_themepark_theme) }}
     themepark-requestrr:
       plugin:
         themepark:
           app: requestrr
-          theme: {{ requestrr_themepark_theme }}
+          theme: {{ requestrr_themepark_theme | default (global_themepark_theme) }}
     themepark-adguard:
       plugin:
         themepark:
           app: adguard
-          theme: {{ adguard_themepark_theme }}
+          theme: {{ adguard_themepark_theme | default (global_themepark_theme) }}
     themepark-gaps:
       plugin:
         themepark:
           app: gaps
-          theme: {{ gaps_themepark_theme }}
-    themepark-vailtwarden:
+          theme: {{ gaps_themepark_theme | default (global_themepark_theme) }}
+    themepark-vaultwarden:
       plugin:
         themepark:
           app: vaultwarden
-          theme: {{ vaultwarden_themepark_theme }}
+          theme: {{ vaultwarden_themepark_theme | default (global_themepark_theme) }}
     themepark-kitana:
       plugin:
         themepark:
           app: kitana
-          theme: {{ kitana_themepark_theme }}
+          theme: {{ kitana_themepark_theme | default (global_themepark_theme) }}
     themepark-resilio-sync:
       plugin:
         themepark:
           app: resilio-sync
-          theme: {{ resilio_sync_themepark_theme }}
+          theme: {{ resilio_sync_themepark_theme | default (global_themepark_theme) }}
     themepark-moviematch:
       plugin:
         themepark:
           app: moviematch
-          theme: {{ moviematch_themepark_theme }}
+          theme: {{ moviematch_themepark_theme | default (global_themepark_theme) }}
     themepark-petio:
       plugin:
         themepark:
           app: petio
-          theme: {{ petio_themepark_theme }}
+          theme: {{ petio_themepark_theme | default (global_themepark_theme) }}

--- a/roles/traefik/templates/themepark.yml.j2
+++ b/roles/traefik/templates/themepark.yml.j2
@@ -15,6 +15,11 @@ http:
         themepark:
           app: nzbhydra2
           theme: {{ nzbhydra2_themepark_theme }}
+    themepark-plex:
+      plugin:
+        themepark:
+          app: plex
+          theme: {{ plex_themepark_theme }}
     themepark-portainer:
       plugin:
         themepark:


### PR DESCRIPTION
This PR adds support for the [Traefik Theme-Park Plugin](https://github.com/packruler/traefik-themepark) which opens up the ability to apply theme.park themes to additional apps.

Enable the plugin globally with: `global_themepark_plugin_enabled: true` in inventories.

With this PR, the Plex role will require the plugin for themes rather than using the existing script method as the Plex image utilizes a version of s6 overlay that is no longer compatible with the scrips.

Support for the following apps is included:
Emby
NZBHydra2
Overseerr
Plex
Portainer

Middlewares are defined for the following apps as well, but the variables and logic are not built at this time:
AdGuard
Gaps
Guacamole
Kitana
MovieMatch
Netdata
Petio
Requestrr
Resilio-Sync
VaultWarden