### PR TITLE
Dev/fallback distro

### DIFF
--- a/defaults/adv_settings.yml.default
+++ b/defaults/adv_settings.yml.default
@@ -22,9 +22,12 @@ traefik:
     jaeger: jaeger
   error_pages: no
 mounts:
-  remote: rclone_vfs
+  remote: rclone_vfs # or rclone_vfs_cache
   ipv4_only: no
   feeder: no
+  #rclone_vfs_cache_dir: "/mnt/cache/rclone/vfs"
+  #rclone_vfs_cache_max_size: "200G"
+  #rclone_vfs_cache_max_age: "2160h"
 gpu:
   intel: yes
   nvidia: no

--- a/inventories/group_vars/all.yml
+++ b/inventories/group_vars/all.yml
@@ -90,6 +90,8 @@ use_nvidia: "{{ gpu.nvidia }}"
 # System
 ################################
 
+ansible_distribution_release_fallback: "jammy"
+
 server_root_path: "/"
 
 server_appdata_path: "{{ server_root_path | regex_replace('\\/$', '') + '/opt' }}"

--- a/resources/tasks/docker/create_docker_container.yml
+++ b/resources/tasks/docker/create_docker_container.yml
@@ -49,7 +49,7 @@
     restart_retries: "{{ lookup('vars', _var_prefix + '_docker_restart_retries', default=omit) }}"
     security_opts: "{{ lookup('vars', _var_prefix + '_docker_security_opts', default=omit) }}"
     state: started
-    stop_timeout: "{{ lookup('vars', _var_prefix + '_docker_stop_timeout', default='10') }}"
+    stop_timeout: "{{ lookup('vars', _var_prefix + '_docker_stop_timeout', default='30') }}"
     sysctls: "{{ lookup('vars', _var_prefix + '_docker_sysctls', default=omit) }}"
     tls_hostname: localhost
     user: "{{ lookup('vars', _var_prefix + '_docker_user', default=omit) }}"

--- a/resources/tasks/docker/remove_docker_container.yml
+++ b/resources/tasks/docker/remove_docker_container.yml
@@ -19,5 +19,5 @@
     force_kill: "{{ lookup('vars', _var_prefix + '_docker_force_kill', default=omit) }}"
     name: "{{ lookup('vars', _var_prefix + '_docker_container') }}"
     state: absent
-    stop_timeout: "{{ lookup('vars', _var_prefix + '_docker_stop_timeout', default='10') }}"
+    stop_timeout: "{{ lookup('vars', _var_prefix + '_docker_stop_timeout', default='30') }}"
     tls_hostname: localhost

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -77,7 +77,7 @@ put_docker_dpkg_into_hold: true
 
 docker_service_after: "{{ mount_type }}.service"
 
-docker_service_sleep: 120
+docker_service_sleep: 30
 
 ################################
 # Docker Compose

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -75,9 +75,9 @@
     enabled: true
     daemon_reload: true
 
-- name: Wait for 60 seconds before commencing
+- name: Wait for 40 seconds before commencing
   ansible.builtin.wait_for:
-    timeout: 60
+    timeout: 40
   when: not continuous_integration
 
 - name: "Stop all Docker containers"

--- a/roles/docker/tasks/subtasks/binary/binary.yml
+++ b/roles/docker/tasks/subtasks/binary/binary.yml
@@ -7,6 +7,13 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
+
+- name: Binary | Remove old sources
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/docker.list
+    state: absent
+  when: ansible_distribution == "Ubuntu"
+
 - name: Binary | Remove old official repository entry
   ansible.builtin.apt_repository:
     repo: "{{ docker_apt_repo_url_old }}"

--- a/roles/docker/tasks/subtasks/daemon.yml
+++ b/roles/docker/tasks/subtasks/daemon.yml
@@ -17,6 +17,30 @@
   with_items:
     - /etc/docker
 
+- name: Docker | Check if in a lxc container
+  ansible.builtin.shell: systemd-detect-virt
+  register: isLXC
+
+- name: Docker | Check if in a lxc container
+  ansible.builtin.set_fact:
+    is_lxc: "{{ isLXC.rc == 0 and isLXC.stdout == 'lxc' }}"
+
+- name: Docker | Check if in a lxc container
+  ansible.builtin.set_fact:
+    storage_driver: "{{ (is_lxc) | ternary('fuse-overlayfs',('zfs' in var_lib_file_system.stdout) | ternary('zfs','overlay2')) }}"
+
+- name: Docker | Install fuse-overlayfs
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+  when: is_lxc
+  
+- name: Docker | Install fuse-overlayfs
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+  when: is_lxc
+
 - name: "Daemon | Import 'daemon.json'"
   ansible.builtin.template:
     src: daemon.json.j2

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -1,5 +1,5 @@
 {
-    "storage-driver": "{{ ('zfs' in var_lib_file_system.stdout) | ternary('zfs','overlay2') }}",
+    "storage-driver": "{{ storage_driver }}",
     "userland-proxy": false,
     "log-driver": "json-file",
     "ipv6": {{ 'true' if dns.ipv6 else 'false' }},

--- a/roles/remote/defaults/main.yml
+++ b/roles/remote/defaults/main.yml
@@ -72,9 +72,9 @@ rclone_vfs_mount_start_post_command: |-
 # Rclone VFS Cache
 ################################
 
-rclone_vfs_cache_max_size: 50G
-rclone_vfs_cache_max_age: 504h
-rclone_vfs_cache_dir: ""
+rclone_vfs_cache_max_size: "{{ mounts.rclone_vfs_cache_max_size or '50G' }}"
+rclone_vfs_cache_max_age: "{{ mounts.rclone_vfs_cache_max_age or '504h' }}"
+rclone_vfs_cache_dir: "{{ mounts.rclone_vfs_cache_dir or '' }}"
 
 rclone_vfs_cache_mount_start_command: |-
   /usr/bin/rclone mount \

--- a/roles/system/tasks/subtasks/mounts.yml
+++ b/roles/system/tasks/subtasks/mounts.yml
@@ -23,9 +23,14 @@
     - "{{ ansible_mounts }}"
   when: (item.mount == '/') and (item.fstype == 'ext4')
 
-- name: Mounts | Install 'fuse'
+- name: Mounts | Install 'fuse3'
   ansible.builtin.apt:
-    name: fuse
+    name: fuse3
+    state: present
+
+- name: Mounts | Install 'fuse-overlayfs'
+  ansible.builtin.apt:
+    name: fuse-overlayfs
     state: present
 
 - name: Mounts | Import 'fuse.conf'

--- a/roles/unionfs/defaults/main.yml
+++ b/roles/unionfs/defaults/main.yml
@@ -32,6 +32,12 @@ mergerfs_release_lookup_command: |
     | jq -r ".assets[] | select(.name | test(\"{{ ansible_distribution | lower }}-{{ ansible_distribution_release | lower }}_amd64\")) \
     | .browser_download_url"
 
+
+mergerfs_release_lookup_command_fallback: |
+  curl -s {{ mergerfs_releases_url }} \
+    | jq -r ".assets[] | select(.name | test(\"{{ ansible_distribution | lower }}-{{ ansible_distribution_release_fallback | lower }}_amd64\")) \
+    | .browser_download_url"
+
 mergerfs_download_backup_version: 2.33.5
 
 mergerfs_download_backup_url: "

--- a/roles/unionfs/tasks/subtasks/mergerfs.yml
+++ b/roles/unionfs/tasks/subtasks/mergerfs.yml
@@ -15,6 +15,15 @@
   register: mergerfs_download_url
   ignore_errors: true
 
+- name: "MergerFS | Get Fallback URL for latest mergerfs release"
+  ansible.builtin.shell: "{{ mergerfs_release_lookup_command_fallback }}"
+  args:
+    executable: /bin/bash
+    warn: false
+  register: mergerfs_download_url
+  ignore_errors: true
+  when: mergerfs_download_url.stdout == ""
+
 - name: "MergerFS | Uninstall mergerfs"
   ansible.builtin.apt:
     name: mergerfs

--- a/roles/user/tasks/subtasks/user_account.yml
+++ b/roles/user/tasks/subtasks/user_account.yml
@@ -85,6 +85,7 @@
     group: "{{ user.name }}"
     recurse: true
     follow: false
+  ignore_errors: true
 
 - name: User Account | Reset ownership of '{{ server_appdata_path }}/' path
   ansible.builtin.file:  # noqa risky-file-permissions


### PR DESCRIPTION
- update `adv_settings.yml.default` with rclone_vfs_cache usage (with params: rclone_vfs_cache_dir rclone_vfs_cache_max_size rclone_vfs_cache_max_age )
- added ansible_distribution_release_fallback for when downloading mergerfs on ubuntu 22.10
- removed /etc/apt/sources.list.d/docker.list for resolving conflicts with official docker installation (different gpg signing key)
- use `fuse-overlayfs` inside lxc container since `overlay2` doesn't work (and also fuse3 as its dependency) 

maybe `overlay2` does work but i just couldn't find a way