### PR TITLE
NZBGet: Fix unpause task creation for new installations

### DIFF
--- a/roles/nzbget/defaults/main.yml
+++ b/roles/nzbget/defaults/main.yml
@@ -110,10 +110,10 @@ nzbget_config_new_installs_settings_default:
   # HealthCheck
   - { regexp: '^HealthCheck\s?=.*', line: 'HealthCheck=Delete' }
   # Unpauser task
-  - { regexp: '^#?Task2\.Time\s?=.*', line: 'Task2.Time=*,*:00,*:15,*:30,*:45' }
-  - { regexp: '^#?Task2\.WeekDays\s?=.*', line: 'Task2.WeekDays=1-7' }
-  - { regexp: '^#?Task2\.Command\s?=.*', line: 'Task2.Command=UnpauseDownload' }
-  - { regexp: '^#?Task2\.Param\s?=.*', line: 'Task2.Param=' }
+  - { regexp: '^#?Task1\.Time\s?=.*', line: 'Task1.Time=*,*:00,*:15,*:30,*:45' }
+  - { regexp: '^#?Task1\.WeekDays\s?=.*', line: 'Task1.WeekDays=1-7' }
+  - { regexp: '^#?Task1\.Command\s?=.*', line: 'Task1.Command=UnpauseDownload' }
+  - { regexp: '^#?Task1\.Param\s?=.*', line: 'Task1.Param=' }
   # Scripts
   - { regexp: '^ShellOverride\s?=.*', line: 'ShellOverride=.py=/usr/bin/python3' }
   - { regexp: '^Extensions\s?=.*', line: 'Extensions=nzbgetpp/unzip.py, flatten.py, DeleteSamples.py, HashRenamer.py, reverse_name.py' }


### PR DESCRIPTION
Unpause task was failing to be created for new installs. Settings change was successful as part of the role, however NZBGet will not load Task2 if Task1 is not present. Attempting to create Task1 to save and reload removes the Task2 entry from the config entirely.

Changed this replacement back to Task1, in line with previous CB Master behaviour. Unclear if there was any particular reason this was changed to Task2 on CB Develop as no other tasks were created.