### PR TITLE
Overseerr: remove now obsolete cache mount

### DIFF
--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -115,7 +115,6 @@ overseerr_docker_commands: "{{ lookup('vars', overseerr_name + '_docker_commands
 # Volumes
 overseerr_docker_volumes_default:
   - "{{ overseerr_paths_location }}:/app/config"
-  - "{{ overseerr_paths_cache }}:/app/.next/cache"
 overseerr_docker_volumes_custom: []
 overseerr_docker_volumes: "{{ lookup('vars', overseerr_name + '_docker_volumes_default', default=overseerr_docker_volumes_default)
                               + lookup('vars', overseerr_name + '_docker_volumes_custom', default=overseerr_docker_volumes_custom) }}"


### PR DESCRIPTION
As of v1.31.0:

> This release introduces our new image caching. We are now directly caching the images from TMDB instead of letting NextJS re-optimize them. This gives us a few new benefits (assuming you enable image caching in the settings).
> 
> -   We now store cached images in your mounted config folder, which means the cache will persist between updates. (If you previously had a volume pointing to the .next cache directory, its no longer necessary)