### PR TITLE
replaces cloudplow rc url with default supplied in rclone_vfs service

### DIFF
--- a/roles/cloudplow/templates/config.json.j2
+++ b/roles/cloudplow/templates/config.json.j2
@@ -26,7 +26,7 @@
                 "4": "20M",
                 "5": "10M"
             },
-            "url": "http://localhost:7949"
+            "url": "http://localhost:5572"
         }
     },
     "remotes": {


### PR DESCRIPTION
Simply changes the port to match defaults