### PR TITLE
feat(resources): expand get_info to include overseerr

### DIFF
--- a/resources/tasks/instances/get_info.yml
+++ b/resources/tasks/instances/get_info.yml
@@ -41,3 +41,10 @@
     plex_name: "{{ item }}"
   with_items: "{{ plex_instances }}"
   when: "'plex' in get_info_list"
+
+- name: Resources | Tasks | Instances | Get Info | Run Overseerr Tasks
+  ansible.builtin.include_tasks: overseerr.yml
+  vars:
+    overseerr_name: "{{ item }}"
+  with_items: "{{ overseerr_instances }}"
+  when: "'overseerr' in get_info_list"

--- a/resources/tasks/instances/overseerr.yml
+++ b/resources/tasks/instances/overseerr.yml
@@ -1,0 +1,31 @@
+##############################################################################
+# Title:         Saltbox: Resources | Tasks | Instances | Get Overseerr Info #
+# Author(s):     salty, keldian                                              #
+# URL:           https://github.com/saltyorg/Saltbox                         #
+# --                                                                         #
+##############################################################################
+#                   GNU General Public License v3.0                          #
+##############################################################################
+---
+- name: Resources | Tasks | Instances | Get Info | Check if Overseerr exists
+  ansible.builtin.stat:
+    path: "{{ overseerr_paths_config_location }}"
+  register: overseerr_paths_config_location_stat
+
+- name: Resources | Tasks | Instances | Get Info | Overseerr API Key tasks
+  block:
+
+    - name: Resources | Tasks | Instances | Get Info | Fetch Overseerr API Key
+      ansible.builtin.set_fact:
+        jsondata: "{{ lookup('ansible.builtin.file', overseerr_paths_config_location) }}"
+
+    - name: Resources | Tasks | Instances | Get Info | Set 'overseerr_info' variable
+      ansible.builtin.set_fact:
+        overseerr_info: "{{ overseerr_info | default({}) | combine({overseerr_name: {'name': overseerr_name, 'url': overseerr_web_url, 'api_key': jsondata.main.apiKey}}) }}"
+
+  when: (overseerr_paths_config_location_stat.stat.exists)
+
+- name: Resources | Tasks | Instances | Get Info | Set 'overseerr_info' variable
+  ansible.builtin.set_fact:
+    overseerr_info: "{{ overseerr_info | default({}) | combine({overseerr_name: {'name': overseerr_name, 'url': overseerr_web_url, 'api_key': 'not installed'}}) }}"
+  when: (not overseerr_paths_config_location_stat.stat.exists)

--- a/resources/tasks/instances/overseerr.yml
+++ b/resources/tasks/instances/overseerr.yml
@@ -13,8 +13,8 @@
   register: overseerr_paths_config_location_stat
 
 - name: Resources | Tasks | Instances | Get Info | Overseerr API Key tasks
+  when: overseerr_paths_config_location_stat.stat.exists
   block:
-
     - name: Resources | Tasks | Instances | Get Info | Fetch Overseerr API Key
       ansible.builtin.set_fact:
         jsondata: "{{ lookup('ansible.builtin.file', overseerr_paths_config_location) }}"
@@ -22,8 +22,6 @@
     - name: Resources | Tasks | Instances | Get Info | Set 'overseerr_info' variable
       ansible.builtin.set_fact:
         overseerr_info: "{{ overseerr_info | default({}) | combine({overseerr_name: {'name': overseerr_name, 'url': overseerr_web_url, 'api_key': jsondata.main.apiKey}}) }}"
-
-  when: (overseerr_paths_config_location_stat.stat.exists)
 
 - name: Resources | Tasks | Instances | Get Info | Set 'overseerr_info' variable
   ansible.builtin.set_fact:

--- a/roles/overseerr/defaults/main.yml
+++ b/roles/overseerr/defaults/main.yml
@@ -23,6 +23,7 @@ overseerr_paths_cache: "{{ overseerr_paths_location }}/cache"
 overseerr_paths_folders_list:
   - "{{ overseerr_paths_location }}"
   - "{{ overseerr_paths_cache }}"
+overseerr_paths_config_location: "{{ overseerr_paths_location }}/settings.json"
 
 ################################
 # Web


### PR DESCRIPTION
This started to seem like a good idea as I was running saltbox_mod trials for different media cleanup apps that connect to Overseerr's API.

Tested with multiple Overseerr instances being looped through, and working.