### PR TITLE
feat(media-server): make autoscan deployment overridable

### DIFF
--- a/roles/media_server/defaults/main.yml
+++ b/roles/media_server/defaults/main.yml
@@ -8,3 +8,4 @@
 ##########################################################################
 ---
 media_servers_enabled: ["plex"]
+media_server_autoscan_enabled: true

--- a/roles/media_server/tasks/main.yml
+++ b/roles/media_server/tasks/main.yml
@@ -17,3 +17,4 @@
 - name: "Execute Autoscan role"
   ansible.builtin.include_role:
     name: "autoscan"
+  when: media_server_autoscan_enabled


### PR DESCRIPTION
I figured it would be cleaner than my current solution of adding `media-server` to skipped tags, for skipping autoscan. 