### PR TITLE
feat(traefik): add master machine feature for authentik

### DIFF
--- a/inventories/group_vars/all.yml
+++ b/inventories/group_vars/all.yml
@@ -157,6 +157,13 @@ global_themepark_plugin_enabled: false
 
 authelia_is_master: "{{ authelia.master | bool }}"
 
+
+################################
+# Authentik
+################################
+
+authentik_is_master: "{{ authelia.master | bool }}"
+
 ################################
 # ZeroSSL
 ################################

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -446,7 +446,9 @@ traefik_docker_labels_default:
                                                                 else authelia_web_url + '/api/verify?auth=basic&rd=' + authelia_web_url + '/' }}"
   traefik.http.middlewares.authelia-basic.forwardauth.trustForwardHeader: "true"
   traefik.http.middlewares.authelia-basic.forwardauth.authResponseHeaders: "Remote-User, Remote-Groups, Remote-Name, Remote-Email"
-  traefik.http.middlewares.authentik.forwardauth.address: "http://{{ authentik_name }}:9000/outpost.goauthentik.io/auth/traefik"
+  traefik.http.middlewares.authentik.forwardauth.address: "{{ 'http://' + authentik_name + ':9000/outpost.goauthentik.io/auth/traefik'
+                                                          if authelia_is_master
+                                                          else authentik_web_url + '/outpost.goauthentik.io/auth/traefik' }}"
   traefik.http.middlewares.authentik.forwardauth.trustForwardHeader: "true"
   traefik.http.middlewares.authentik.forwardauth.authResponseHeaders: "X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version"
 

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -447,8 +447,8 @@ traefik_docker_labels_default:
   traefik.http.middlewares.authelia-basic.forwardauth.trustForwardHeader: "true"
   traefik.http.middlewares.authelia-basic.forwardauth.authResponseHeaders: "Remote-User, Remote-Groups, Remote-Name, Remote-Email"
   traefik.http.middlewares.authentik.forwardauth.address: "{{ 'http://' + authentik_name + ':9000/outpost.goauthentik.io/auth/traefik'
-                                                          if authelia_is_master
-                                                          else authentik_web_url + '/outpost.goauthentik.io/auth/traefik' }}"
+                                                           if authentik_is_master
+                                                           else authentik_web_url + '/outpost.goauthentik.io/auth/traefik' }}"
   traefik.http.middlewares.authentik.forwardauth.trustForwardHeader: "true"
   traefik.http.middlewares.authentik.forwardauth.authResponseHeaders: "X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version"
 

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -90,7 +90,7 @@
 - name: "Import Authentik Role"
   ansible.builtin.include_role:
     name: authentik
-  when: traefik_authentik_enabled and authelia_is_master
+  when: traefik_authentik_enabled and authentik_is_master
 
 - name: "Import Error Pages Role"
   ansible.builtin.include_role:

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -90,7 +90,7 @@
 - name: "Import Authentik Role"
   ansible.builtin.include_role:
     name: authentik
-  when: traefik_authentik_enabled
+  when: traefik_authentik_enabled and authelia_is_master
 
 - name: "Import Error Pages Role"
   ansible.builtin.include_role:


### PR DESCRIPTION
Add the possibility to use `authentik` in a split feeder/media setup