### PR TITLE
Update error_page_template

### DIFF
--- a/roles/error_pages/defaults/main.yml
+++ b/roles/error_pages/defaults/main.yml
@@ -18,7 +18,7 @@ error_pages_name: error_pages
 ################################
 
 # Template options listed here https://github.com/tarampampam/error-pages
-error_pages_template: "l7-dark"
+error_pages_template: "l7"
 
 ################################
 # Docker


### PR DESCRIPTION
error-pages no longer has the template for l7-dark. This creates an error in docker: template 'l7-dark' not found and cannot be used (available templates: [app-down cats connection ghost hacker-terminal l7 lost-in-space noise orient shuffle]) l7 is supported.