### PR TITLE
Update Authentik image to latest stable.

### DIFF
--- a/roles/authentik/defaults/main.yml
+++ b/roles/authentik/defaults/main.yml
@@ -94,7 +94,7 @@ authentik_docker_container: "{{ authentik_name }}"
 
 # Image
 authentik_docker_image_pull: true
-authentik_docker_image_tag: "2024.4.3"
+authentik_docker_image_tag: "2024.8.1"
 authentik_docker_image: "ghcr.io/goauthentik/server:{{ authentik_docker_image_tag }}"
 
 # Ports


### PR DESCRIPTION
In August a new stable version of Authentik was released. I propose updating the image to 2024.8.1, which is the latest stable version of the docker image.