### PR TITLE
Update roles/nvidia/tasks/main.yml to support more than 1 nVidia card

### DIFF
--- a/roles/nvidia/tasks/main.yml
+++ b/roles/nvidia/tasks/main.yml
@@ -30,8 +30,8 @@
 
 - name: Fetch Nvidia card info
   ansible.builtin.shell: |
-    if [ `lspci | grep -c -E '.*VGA.*NVIDIA|.*3D controller.*NVIDIA'` -eq 1 ]; then
-      lspci -s $(lspci | grep -E '.*VGA.*NVIDIA|.*3D controller.*NVIDIA' | cut -d' ' -f 1)
+    if [ `lspci | grep -c -E '.*VGA.*NVIDIA|.*3D controller.*NVIDIA'` -gt 0 ]; then
+      lspci | grep -E '.*VGA.*NVIDIA|.*3D controller.*NVIDIA'
     else
       echo ""
     fi


### PR DESCRIPTION
Original code would fail if more than one nVidia card was present in the system.  New code has been tested with 2 cards; should work with any number of nVidia cards > 0.