### PR TITLE
chore: add dynu provider support

### DIFF
--- a/defaults/providers.yml.default
+++ b/defaults/providers.yml.default
@@ -5,6 +5,8 @@ cloudns:
   password:
 duckdns:
   token:
+dynu:
+  api_key:
 godaddy:
   api_key:
   api_secret:

--- a/roles/ddclient/templates/ddclient.conf.j2
+++ b/roles/ddclient/templates/ddclient.conf.j2
@@ -223,6 +223,18 @@ password={{ cloudflare.api }}             \
 # protocol=duckdns hostwithoutduckdnsorg
 
 ##
+## Dynu (https://www.dynu.com)
+##
+#                                   
+# use=web, web=checkip.dynu.com/, web-skip='IP Address'    # Get ip from server.
+# # use=if, if=eth0     # alternative to use=web
+# server=api.dynu.com                                      # IP update server.
+# protocol=dyndns2                        
+# login=myusername                                         # Your username.
+# password=YOURPASSWORD                                    # Password or MD5/SHA256 hash of password.
+# MYDOMAIN.DYNU.COM                                        # List one or more hostnames one on each line.
+
+##
 ## Freemyip (http://freemyip.com/)
 ##
 #

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -175,6 +175,9 @@ traefik_dns_provider_cloudns:
 traefik_dns_provider_duckdns:
   DUCKDNS_TOKEN: "{{ duckdns.token }}"
 
+traefik_dns_provider_dynu:
+  DYNU_API_KEY: "{{ dynu.api_key }}"
+
 traefik_dns_provider_godaddy:
   GODADDY_API_KEY: "{{ godaddy.api_key }}"
   GODADDY_API_SECRET: "{{ godaddy.api_secret }}"


### PR DESCRIPTION
- Updated defaults/providers.yml.default to include dynu API key
- Modified ddclient.conf.j2 template to add dynu configuration example
- Extended traefik defaults to support dynu DNS provider integration