### PR TITLE
feat(os): add Ubuntu 26.04 LTS (Resolute Raccoon) support

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -27,7 +27,7 @@ If issue occurs during Ansible playbook, run playbook with `-vv` to output detai
 
 **System Information**
 
- - Operating System: [e.g. Ubuntu Server 20.04 LTS]
+ - Operating System: [e.g. Ubuntu Server 24.04 LTS]
  - Linux Kernel: [e.g. 5.8]
 
 **Additional context**

--- a/.github/workflows/saltbox-os.yml
+++ b/.github/workflows/saltbox-os.yml
@@ -46,7 +46,7 @@ jobs:
       - id: set-matrix
         run: |
           ROLES=$(awk '/# Core/{flag=1;next}/# Apps End/{flag=0}flag' saltbox.yml | awk '!/#/' | awk -F'[][]' '{print $2}' | tr '\n' ',' | sed 's/,*$//' | awk -F',' '{ for( i=1; i<=NF; i++ ) print $i }' | awk '{ gsub(/ /,""); print }'| sort -u | awk -vORS=, '{ print $1 }' | sed 's/,$/\n/' | sed "s/.\(roles\|common\|hetzner\|kernel\|motd\|mounts\|nvidia\|nvidia-purge\|preinstall\|rclone\|scripts\|shell\|system\|traefik\|traefik-reset-certs\|user\|cloudflare\|plex-db\|arr-db\|ddns\|cloudplow\|cloudplow-reset\|btrfsmaintenance\|download-clients\|download-indexers\|media-server\|python\|yyq\|crowdsec\|postgres-host\).,//g")
-          echo "matrix={\"roles\":[$ROLES],\"os\":[\"22.04\",\"24.04\"]}" >> $GITHUB_OUTPUT
+          echo "matrix={\"roles\":[$ROLES],\"os\":[\"22.04\",\"24.04\",\"26.04\"]}" >> $GITHUB_OUTPUT
 
   install:
     name: '${{ matrix.roles }}-${{ matrix.os }}'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Saltbox is an Ansible-based solution for rapidly deploying a Docker containerized cloud media server heavily based on [Cloudbox](https://github.com/Cloudbox/Cloudbox).
 
-This project was designed for x64 machines running LTS releases of Ubuntu Server 22.04 or 24.04. 
+This project was designed for x64 machines running LTS releases of Ubuntu Server 22.04, 24.04, or 26.04.
 
 Non-LTS releases of Ubuntu or Desktop installs are not supported. 
 
@@ -256,3 +256,4 @@ Thank you to [JetBrains](https://www.jetbrains.com/) for providing us with free 
     </td>
 </tr>
 </table>
+ 

--- a/inventories/group_vars/all.yml
+++ b/inventories/group_vars/all.yml
@@ -20,6 +20,7 @@ saltbox_venv_path: "/srv/ansible/venv"
 
 resources_tasks_path: "/srv/git/saltbox/resources/tasks"
 resources_path: "/srv/git/saltbox/resources"
+saltbox_repo: "saltyorg/Saltbox"
 
 ################################
 # Role Variables

--- a/roles/kernel/defaults/main.yml
+++ b/roles/kernel/defaults/main.yml
@@ -32,3 +32,6 @@ kernel_update_apt_package_22: linux-generic-hwe-22.04
 
 # Do not edit or override using the inventory
 kernel_update_apt_package_24: linux-generic-hwe-24.04
+
+# Do not edit or override using the inventory
+kernel_update_apt_package_26: linux-generic-hwe-26.04

--- a/roles/kernel/tasks/main.yml
+++ b/roles/kernel/tasks/main.yml
@@ -44,6 +44,16 @@
     - (not continuous_integration)
     - kernel_install_hwe
 
+# Ubuntu 26.04 HWE Update
+- name: Ubuntu 26.04 Update Tasks
+  ansible.builtin.include_tasks: "subtasks/07_update_resolute.yml"
+  when:
+    - (ansible_facts['distribution'] == 'Ubuntu')
+    - (ansible_facts['distribution_version'] is version('26.04', '=='))
+    - (ansible_facts['kernel'] is version('7.0', '<'))
+    - (not continuous_integration)
+    - kernel_install_hwe
+
 - name: Restart Tasks
   ansible.builtin.include_tasks: "subtasks/06_restart.yml"
   when:

--- a/roles/kernel/tasks/subtasks/07_update_resolute.yml
+++ b/roles/kernel/tasks/subtasks/07_update_resolute.yml
@@ -1,0 +1,35 @@
+#########################################################################
+# Title:         Saltbox: Kernel | Resolute Update Tasks                #
+# Author(s):     salty                                                  #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Update | Update linux kernel
+  ansible.builtin.apt:
+    name: "{{ kernel_update_apt_package_26 }}"
+    install_recommends: true
+    update_cache: true
+    state: latest
+  register: r
+
+- name: Update | Fix broken APT install
+  ansible.builtin.shell: "{{ kernel_update_apt_fix }}"
+  when: r.changed
+
+- name: Update | Set 'reboot_is_necessary' variable
+  ansible.builtin.set_fact:
+    reboot_is_necessary: true
+  when: r.changed
+
+- name: Update | Kernel was updated
+  ansible.builtin.debug:
+    msg: "Kernel was updated."
+  when: r.changed
+
+- name: Update | Kernel was not updated
+  ansible.builtin.debug:
+    msg: "Kernel was not updated."
+  when: (not r.changed)

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -25,7 +25,9 @@
         if (ansible_facts['distribution_version'] is version('22.04', '=='))
         else '3.12'
           if (ansible_facts['distribution_version'] is version('24.04', '=='))
-          else 'unknown' }}
+          else '3.14'
+            if (ansible_facts['distribution_version'] is version('26.04', '=='))
+            else 'unknown' }}
 
 - name: Assert system Python matches Ubuntu release
   ansible.builtin.assert:

--- a/roles/sanity_check/tasks/subtasks/09_repo.yml
+++ b/roles/sanity_check/tasks/subtasks/09_repo.yml
@@ -18,7 +18,7 @@
 - name: Repository | Check Git Origin Hash
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/git/github_api_request.yml"
   vars:
-    github_api_url: "https://api.github.com/repos/saltyorg/Saltbox/commits?sha={{ git_branch.stdout }}"
+    github_api_url: "https://api.github.com/repos/{{ saltbox_repo | default('saltyorg/Saltbox') }}/commits?sha={{ git_branch.stdout }}"
     github_api_result_var: git_origin_commits_api
     github_api_timeout: 3
     github_api_headers:


### PR DESCRIPTION
## Summary

Adds support for Ubuntu Server 26.04 LTS ("Resolute Raccoon", codename
`resolute`) alongside the existing 22.04 and 24.04 releases. No changes for
existing releases.

The `sanity_check` role verifies the local commit against the GitHub API using
a hardcoded `saltyorg/Saltbox` URL, so installs running from a fork or a
feature branch always fail this check. This makes the repository configurable
via a new `saltbox_repo` variable that defaults to `saltyorg/Saltbox`. 

This also helps anyone maintaining a downstream fork or a long-lived custom
branch of Saltbox: the check now validates against whatever repository the
install actually tracks, instead of always assuming upstream. I split this change 
into its own commit in case another approach is desired.

## Changes

- **kernel**: add `linux-generic-hwe-26.04` and a `07_update_resolute`
  subtask that mirrors the noble (24.04) HWE flow
- **python**: map 26.04 to the system Python (3.14)
- **CI**: add 26.04 to the supported-OS matrix
 **(note that [ubuntu-26.04 runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) aren't yet available on GitHub, see [PR](https://github.com/actions/runner-images/pull/14123))**
- **meta**: update the README supported-OS list and the bug-report template
- **inventories/group_vars/all.yml**: add `saltbox_repo`, defaulting to
  `saltyorg/Saltbox`
- **roles/sanity_check/tasks/subtasks/09_repo.yml**: build the GitHub API URL
  from `{{ saltbox_repo | default('saltyorg/Saltbox') }}`

## Testing

- Started with a clean Ubuntu 26.04 (resolute) VM
- Confirmed `preinstall` completes successfully
- Confirmed `core` completes successfully
- Confirmed `saltbox` completes successfully
- Confirmed local fact gathering with `saltbox.fact` works on Ubuntu 26.04

## Compatibility

Additive only; 22.04 and 24.04 behavior is unchanged.

## Related

Adding Ubuntu 26.04 support will require merging changes across
**Saltbox**, **sb**, **sb-go**, and **docs**. Related PRs in these repos will be
submitted momentarily.

Test helper:
[feat-ubuntu-26.04-test.sh](https://github.com/user-attachments/files/28177497/feat-ubuntu-26.04-test.sh)


## Related PRs:

- **sb:** https://github.com/saltyorg/sb/pull/116
- **sb-go:** https://github.com/saltyorg/sb-go/pull/46
- **docs:** https://github.com/saltyorg/docs/pull/403