### PR TITLE
fix(authentik): skip postgres health wait when postgres_deploy is false

### DIFF
--- a/roles/authentik/tasks/main.yml
+++ b/roles/authentik/tasks/main.yml
@@ -90,6 +90,7 @@
   register: authentik_postgres_container_info
   retries: 15
   delay: 10
+  when: lookup('role_var', '_postgres_deploy', role='authentik')
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"


### PR DESCRIPTION
### Problem

`roles/authentik/tasks/main.yml` waits for the Postgres container to become healthy without checking whether that container was deployed:

```yaml
- name: "Wait for {{ ... _postgres_name ... }} container to be healthy"
  community.docker.docker_container_info:
    name: "{{ ... _postgres_name ... }}"
  until: "authentik_postgres_container_info.container.State.Health.Status == 'healthy'"
  register: authentik_postgres_container_info
  retries: 15
  delay: 10
```

With `authentik_role_postgres_deploy: false` — the supported way to run Authentik against an external Postgres — that container never exists, so `docker_container_info` returns `container: None` and the `until` expression fails:

```
Error while evaluating conditional: object of type 'NoneType' has no attribute 'State'
```

### Impact

The task runs *after* `Remove existing Docker containers`, so by the time the play aborts, `authentik` and `authentik-worker` have already been removed. On a host serving SSO that is an outage rather than a clean failure, and the retries stall it for ~150s first.

### Fix

Guard the task with the same flag that controls whether the Postgres container is deployed.

### Reproduce

Set `authentik_role_postgres_deploy: false`, point `AUTHENTIK_POSTGRESQL__HOST`/`PORT` at an external instance, then run `sb install authentik`.
