### PR TITLE
fix(cloudplow): exclude SQLite WAL sidecar files from uploads

### DIFF
--- a/roles/cloudplow/templates/config.json.j2
+++ b/roles/cloudplow/templates/config.json.j2
@@ -38,7 +38,10 @@
       "rclone_excludes": [
         "**partial~",
         "**_HIDDEN~",
-        "*.db"
+        "*.db",
+        "*.db-wal",
+        "*.db-shm",
+        "*.db-journal"
       ],
       "rclone_extras": {
         {{ (cloudplow_rclone_google_template


### PR DESCRIPTION
## Problem

`rclone_excludes` already carries `*.db`, which keeps a SQLite database in an
upload folder from being moved to the remote. It does not cover the sidecar
files SQLite creates next to that database the first time an app opens it
read/write:

- `<name>.db-wal`
- `<name>.db-shm`
- `<name>.db-journal`

Those suffixes are not matched by `*.db`.

When an app keeps its database inside a folder cloudplow uploads from — an
ebook library with its `metadata.db` in the library root is the case I hit —
the `move` sweep sends the sidecars to the remote and deletes the local
copies. rclone's default vfs-cache-mode cannot serve the in-place partial
writes SQLite needs, so every subsequent write to the database fails with
`disk I/O error`, indefinitely, until the remote copies are deleted by hand.
The database itself is protected; the files that make it usable are not.

## Change

Add the three sidecar patterns beside the existing `*.db` entry in
`config.json.j2`, so new installs get them by default.

Existing installs are unaffected and will need the patterns added to their
own `config.json` by hand. An earlier revision of this PR also added a `jq`
task to apply them to deployed configs; that has been dropped per review, as
it would have grown what Saltbox manages in a config file after deployment.

## Testing

Not run against a live Saltbox install — the change is three literal entries
appended to an existing array in the template. Flagging that plainly rather
than implying more coverage than there is.
