### PR TITLE
fix(shell): remove unsupported --headless flag from oh-my-posh font install

### DIFF
--- a/roles/shell/tasks/subtasks/shell/zsh.yml
+++ b/roles/shell/tasks/subtasks/shell/zsh.yml
@@ -115,7 +115,7 @@
       ansible.builtin.shell: "curl -s https://ohmyposh.dev/install.sh | bash -s -- -d /usr/local/bin/"
 
     - name: ZSH | Install Meslo Nerd Font
-      ansible.builtin.shell: "/usr/local/bin/oh-my-posh font install meslo --headless"
+      ansible.builtin.shell: "/usr/local/bin/oh-my-posh font install meslo"
 
     - name: "ZSH | Add Oh My Posh to '{{ shell_zsh_zshrc_path }}'"
       ansible.builtin.blockinfile:


### PR DESCRIPTION
Problem:
```
TASK [shell : ZSH | Install Meslo Nerd Font] ***********************************
Wednesday 26 August 2026  16:58:10 +0200 (0:00:05.856)       0:07:03.237 ****** 
[ERROR]: Task failed: Module failed: The command exited with a non-zero return code.
Origin: /srv/git/saltbox/roles/shell/tasks/subtasks/shell/zsh.yml:117:7

115       ansible.builtin.shell: "curl -s https://ohmyposh.dev/install.sh | bash -s -- -d /usr/local/bin/"
116
117     - name: ZSH | Install Meslo Nerd Font
          ^ column 7

fatal: [localhost]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/oh-my-posh font install meslo --headless", "delta": "0:00:00.040289", "end": "2026-08-26 16:58:12.419709", "msg": "The command exited with a non-zero return code.", "rc": 70, "start": "2026-08-26 16:58:12.379420", "stderr": "Error: unknown flag: --headless\nUsage:\n  oh-my-posh font install <font> [flags]\n\nFlags:\n  -h, --help                help for install\n      --zip-folder string   the folder inside the zip file to install fonts from\n\nGlobal Flags:\n  -c, --config string   config file path\n      --plain           plain text output (no ANSI)\n      --trace           enable tracing", "stderr_lines": ["Error: unknown flag: --headless", "Usage:", "  oh-my-posh font install <font> [flags]", "", "Flags:", "  -h, --help                help for install", "      --zip-folder string   the folder inside the zip file to install fonts from", "", "Global Flags:", "  -c, --config string   config file path", "      --plain           plain text output (no ANSI)", "      --trace           enable tracing"], "stdout": "", "stdout_lines": []}
```

After fix:
```
TASK [shell : ZSH | Install Oh My Posh] ***************************************************************************************************************************
Wednesday 26 August 2026  17:14:08 +0200 (0:00:00.487)       0:02:53.369 ****** 
changed: [localhost]

TASK [shell : ZSH | Install Meslo Nerd Font] **********************************************************************************************************************
Wednesday 26 August 2026  17:14:14 +0200 (0:00:05.462)       0:02:58.831 ****** 
changed: [localhost]

TASK [shell : ZSH | Add Oh My Posh to '/home/seed/.zshrc'] ********************************************************************************************************
Wednesday 26 August 2026  17:14:56 +0200 (0:00:42.012)       0:03:40.844 ****** 
ok: [localhost]
```